### PR TITLE
Only initConfig when the event comes from our own settings being changed

### DIFF
--- a/src/main/java/com/ClanEventAttendance/ClanEventAttendancePlugin.java
+++ b/src/main/java/com/ClanEventAttendance/ClanEventAttendancePlugin.java
@@ -468,7 +468,10 @@ public class ClanEventAttendancePlugin extends Plugin
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
-		initConfig();
+		if (event.getGroup().equals("ClanEventAttendance"))
+		{
+			initConfig();
+		}
 	}
 
 	private void initConfig()


### PR DESCRIPTION
Group as specified in `ClanEventAttendanceConfig`